### PR TITLE
integrate pytest-metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ commands:
             . venv/bin/activate;
             pip install -e .;
             pip install -e .[dev]
+            pip install -e .[optional]
       - save_cache:
           paths:
             - ./venv

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ pip install pytest-lockable
 pytest_plugins = ("lockable.plugin",)
 ```
 
+## integrations
+
+pytest-lockable integrates pytest-metadata - when resource is 
+reserved and [pytest-metadata](https://github.com/pytest-dev/pytest-metadata) plugin are in use metadata will 
+be generated from resource json with  `resource_` -prefixes.
+e.g. `resource_id=<id>`. 
+Same dictionary are also recorded to testsuite property using
+[record_testsuite_property](https://docs.pytest.org/en/stable/reference.html#record-testsuite-property) -method.
+
 ## Usage
 
 Custom options:

--- a/example/conftest.py
+++ b/example/conftest.py
@@ -5,4 +5,4 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 PLUGIN_DIR = os.path.join(TEST_DIR, '../')
 sys.path.insert(0, PLUGIN_DIR)
 
-pytest_plugins = ("lockable.plugin",)  # pylint: disable=invalid-name
+pytest_plugins = ("lockable.plugin", "metadata")  # pylint: disable=invalid-name

--- a/lockable/plugin.py
+++ b/lockable/plugin.py
@@ -148,4 +148,6 @@ def lockable_resource(pytestconfig, record_testsuite_property):
     with lock(predicate, resource_list, timeout_s, lock_folder) as resource:
         for key, value in resource.items():
             record_testsuite_property(f'resource_{key}', value)
+            if pytestconfig.pluginmanager.hasplugin('metadata'):
+                pytestconfig._metadata[f'resource_{key}'] = value
         yield resource

--- a/lockable/plugin.py
+++ b/lockable/plugin.py
@@ -149,5 +149,6 @@ def lockable_resource(pytestconfig, record_testsuite_property):
         for key, value in resource.items():
             record_testsuite_property(f'resource_{key}', value)
             if pytestconfig.pluginmanager.hasplugin('metadata'):
+                # pylint: disable=protected-access
                 pytestconfig._metadata[f'resource_{key}'] = value
         yield resource

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ setup(
         'pydash'
     ],
     extras_require={  # Optional
-        'dev': ['nose', 'coveralls', 'pylint', 'coverage']
+        'dev': ['nose', 'coveralls', 'pylint', 'coverage'],
+        'optional': ['pytest-metadata']
     },
 
     project_urls={  # Optional


### PR DESCRIPTION
add resource related metadata when resource is locked