### PR TITLE
allow to allocate any lockable during test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ Custom options:
 
 Example:
 
+Use shared lockable resource
+``` python
+def test_example(lockable_resource):
+    """ Simple test """
+    print(f'Testing with resource: {lockable_resource}')
+```
+
+Allocate lockable resource during test with given requirements
+``` python
+def test_example(lockable):
+    """ Simple test """
+    with lockable({"my": "requirements"}) as resource:
+        print(f'Testing with resource#: {resource}')
+```
+
 See [example test](example/test_example.py). Usage:
 ```
 cd example

--- a/example/resources.json
+++ b/example/resources.json
@@ -8,5 +8,10 @@
     "id": "1235",
     "online": true,
     "hostname": "localhost"
+  },
+  {
+    "id": "1236",
+    "online": true,
+    "hostname": "localhost"
   }
 ]

--- a/example/test_example.py
+++ b/example/test_example.py
@@ -14,7 +14,9 @@ def test_example1(lockable_resource):
     sleep(1)
 
 
-def test_example2(lockable_resource):
+def test_example2(lockable_resource, lockable):
     """ Simple test """
     print(f'Testing with resource: {lockable_resource}')
-    sleep(1)
+    with lockable({}) as resource:
+        print(f'Testing with resource#2: {resource}')
+        sleep(1)

--- a/lockable/plugin.py
+++ b/lockable/plugin.py
@@ -172,7 +172,7 @@ def lockable(pytestconfig, record_testsuite_property):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def lockable_resource(pytestconfig, lockable):
+def lockable_resource(pytestconfig, lockable):  # pylint: disable=redefined-outer-name
     """
     pytest fixture that lock suitable resource and yield it
 

--- a/lockable/plugin.py
+++ b/lockable/plugin.py
@@ -81,13 +81,14 @@ def _try_lock(candidate, lock_folder):
     resource_id = candidate.get("id")
     try:
         lock_file = os.path.join(lock_folder, f"{resource_id}.lock")
-        lockable = FileLock(lock_file)
-        lockable.acquire(timeout=0)
+        _lockable = FileLock(lock_file)
+        _lockable.acquire(timeout=0)
         print(f'Allocated resource: {resource_id}')
 
         def release():
+            nonlocal _lockable
             print(f'Release resource: {resource_id}')
-            lockable.release()
+            _lockable.release()
             try:
                 os.remove(lock_file)
             except OSError as error:


### PR DESCRIPTION
Allow to lock more resources during test case or during another fixture
``` python
def test_example(lockable):
    """ Simple test """
    with lockable({"my": "requirements"}) as resource:
        print(f'Testing with resource#: {resource}')
```