### PR TITLE
use int type for allocation_timeout argument

### DIFF
--- a/pytest_lockable/plugin.py
+++ b/pytest_lockable/plugin.py
@@ -13,7 +13,7 @@ def pytest_addoption(parser):
     group = parser.getgroup("lockable")
     group.addoption("--allocation_hostname", default=socket.gethostname(), help="Allocation host")
     group.addoption("--allocation_requirements", default=None, help="Resource requirements to be allocate")
-    group.addoption("--allocation_timeout", default=10, help="Allocation timeout")
+    group.addoption("--allocation_timeout", type=int, default=10, help="Allocation timeout")
     group.addoption("--allocation_resource_list_file", default='resources.json', help="Available resources list")
     group.addoption("--allocation_lock_folder", default=tempfile.gettempdir(), help="Allocation lockfiles folder")
 


### PR DESCRIPTION
argparse doesn't convert string automatically to int which leads that allocation_timeout argument was not handled properly.

See spec: https://docs.python.org/3/library/argparse.html#type