### PR TITLE
update py-lockable@v0.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     python_requires='>=3.7, <4',
     install_requires=[
         'pytest',
-        'lockable==0.5.0'
+        'lockable==0.6.0'
     ],
     extras_require={  # Optional
         'dev': ['nose', 'coveralls', 'pylint', 'coverage'],


### PR DESCRIPTION
https://github.com/jupe/py-lockable/releases/tag/v0.6.0

This makes possible get allocation_queue_time and allocation_time