### PR TITLE
yield Allocation context instead of resource info dictionary

### DIFF
--- a/example/test_example.py
+++ b/example/test_example.py
@@ -18,5 +18,5 @@ def test_example2(lockable_resource, lockable):
     """ Simple test """
     print(f'Testing with resource: {lockable_resource}')
     with lockable.auto_lock({}) as allocation:
-        print(f'Testing with resource#2: {allocation.resource_info}')
+        print(f'Testing with resource#2: {allocation}')
         sleep(1)

--- a/pytest_lockable/plugin.py
+++ b/pytest_lockable/plugin.py
@@ -42,9 +42,9 @@ def lockable_resource(pytestconfig, lockable):  # pylint: disable=redefined-oute
     pytest fixture that lock suitable resource and yield it
     .. code-block:: python
         def test_foo(lockable_resource):
-            print(f'Testing with resource: {lockable_resource}')
+            print(f'Testing with resource: {lockable_resource.resource_info}')
     """
     requirements = pytestconfig.getoption('allocation_requirements')
     timeout_s = pytestconfig.getoption('allocation_timeout')
     with lockable.auto_lock(requirements, timeout_s) as allocation:
-        yield allocation.resource_info
+        yield allocation

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     python_requires='>=3.7, <4',
     install_requires=[
         'pytest',
-        'lockable==0.6.0'
+        'lockable==0.7.0'
     ],
     extras_require={  # Optional
         'dev': ['nose', 'coveralls', 'pylint', 'coverage'],


### PR DESCRIPTION
yield Allocation context instead of resource info dictionary

This is potential breaking change for `lockable_resource` -fixture. it now yield [Allocation](https://github.com/jupe/py-lockable/blob/1f86ff19176521ae05b31d4f044ce8d2848fb179/lockable/allocation.py#L9) -object instead of resource_info. Allocation contains `Allocation:get` method - so this is partially backward compatible. 